### PR TITLE
Add text simplification API using OpenAI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -23,10 +23,12 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/kotlin/com/example/codextest/simplify/SimplifiedText.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/SimplifiedText.kt
@@ -1,0 +1,13 @@
+package com.example.codextest.simplify
+
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+class SimplifiedText(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    val original: String,
+    val simplified: String,
+    val createdAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/example/codextest/simplify/SimplifiedTextRepository.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/SimplifiedTextRepository.kt
@@ -1,0 +1,5 @@
+package com.example.codextest.simplify
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SimplifiedTextRepository : JpaRepository<SimplifiedText, Long>

--- a/src/main/kotlin/com/example/codextest/simplify/SimplifyController.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/SimplifyController.kt
@@ -1,0 +1,17 @@
+package com.example.codextest.simplify
+
+import com.example.codextest.simplify.dto.SimplifyRequest
+import com.example.codextest.simplify.dto.SimplifyResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+class SimplifyController(private val service: SimplifyService) {
+
+    @PostMapping("/simplify")
+    fun simplify(@RequestBody request: SimplifyRequest): ResponseEntity<SimplifyResponse> {
+        val entity = service.simplify(request.text)
+        return ResponseEntity.ok(SimplifyResponse(entity.id!!, entity.original, entity.simplified))
+    }
+}

--- a/src/main/kotlin/com/example/codextest/simplify/SimplifyService.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/SimplifyService.kt
@@ -1,0 +1,16 @@
+package com.example.codextest.simplify
+
+import com.example.codextest.simplify.client.SimplifyClient
+import org.springframework.stereotype.Service
+
+@Service
+class SimplifyService(
+    private val repository: SimplifiedTextRepository,
+    private val client: SimplifyClient
+) {
+    fun simplify(text: String): SimplifiedText {
+        val simplified = client.simplify(text)
+        val entity = SimplifiedText(original = text, simplified = simplified)
+        return repository.save(entity)
+    }
+}

--- a/src/main/kotlin/com/example/codextest/simplify/client/ChatCompletion.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/client/ChatCompletion.kt
@@ -1,0 +1,10 @@
+package com.example.codextest.simplify.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ChatCompletionResponse(val choices: List<Choice>)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Choice(val message: Message)
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Message(val role: String, val content: String)

--- a/src/main/kotlin/com/example/codextest/simplify/client/SimplifyClient.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/client/SimplifyClient.kt
@@ -1,0 +1,32 @@
+package com.example.codextest.simplify.client
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+@Component
+class SimplifyClient(
+    builder: WebClient.Builder,
+    @Value("\${openai.api.key}")
+    private val apiKey: String
+) {
+    private val webClient: WebClient = builder.baseUrl("https://api.openai.com").build()
+
+    fun simplify(text: String): String {
+        val request = mapOf(
+            "model" to "gpt-3.5-turbo",
+            "messages" to listOf(mapOf("role" to "user", "content" to "Simplify the following text: $text"))
+        )
+        val response = webClient.post()
+            .uri("/v1/chat/completions")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer $apiKey")
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(ChatCompletionResponse::class.java)
+            .block()
+            ?: throw IllegalStateException("No response from LLM")
+        return response.choices.firstOrNull()?.message?.content?.trim() ?: text
+    }
+}

--- a/src/main/kotlin/com/example/codextest/simplify/dto/SimplifyRequest.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/dto/SimplifyRequest.kt
@@ -1,0 +1,3 @@
+package com.example.codextest.simplify.dto
+
+data class SimplifyRequest(val text: String)

--- a/src/main/kotlin/com/example/codextest/simplify/dto/SimplifyResponse.kt
+++ b/src/main/kotlin/com/example/codextest/simplify/dto/SimplifyResponse.kt
@@ -1,0 +1,3 @@
+package com.example.codextest.simplify.dto
+
+data class SimplifyResponse(val id: Long, val original: String, val simplified: String)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=codextest
+spring.datasource.url=jdbc:postgresql://localhost:5432/codextest
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.jpa.hibernate.ddl-auto=update
+openai.api.key=

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+openai.api.key=dummy


### PR DESCRIPTION
## Summary
- update Java toolchain version for Gradle
- add H2 config for tests
- implement text simplification service with Spring Boot, JPA and PostgreSQL
- provide REST controller to simplify text through OpenAI API

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684d840e6fb0832ba0eec6bf6191f6c1